### PR TITLE
Fun fact: reset.css overrides the table's border-collapse property

### DIFF
--- a/d2l-table-style.html
+++ b/d2l-table-style.html
@@ -19,7 +19,7 @@ TODO: When ShadowDOM v1 is available, use <slot> and ::slotted
 		<style include="d2l-colors">
 			:host {
 				background-color: transparent;
-				border-collapse: separate;
+				border-collapse: separate !important;
 				border-spacing: 0;
 				display: table;
 				width: 100%;

--- a/demo/reset.html
+++ b/demo/reset.html
@@ -1,0 +1,52 @@
+<link rel="import" href="../../polymer/polymer.html">
+<dom-module id="reset">
+	<template>
+		<style>
+		html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, font, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend {
+margin: 0;
+padding: 0;
+border: 0;
+outline: 0;
+font-size: 100%;
+background: transparent;
+}
+body {
+line-height: 1;
+}
+ul {
+list-style: none;
+}
+blockquote, q {
+quotes: none;
+}
+blockquote:before, blockquote:after,
+q:before, q:after {
+content: '';
+content: none;
+}
+:focus {
+outline: 0;
+}
+table {
+border-collapse: collapse;
+}
+sub {
+vertical-align: sub;
+}
+sup {
+vertical-align: super;
+}
+a, a:hover, a:visited {
+color: #000000;
+text-decoration: none;
+}
+</style>
+</template>
+</dom-module>

--- a/demo/simple-demo.html
+++ b/demo/simple-demo.html
@@ -1,9 +1,10 @@
 <link rel="import" href="../../polymer/polymer.html">
 <link rel="import" href="../d2l-table.html">
+<link rel="import" href="reset.html">
 
 <dom-module id="simple-demo">
 	<template>
-		<style>
+		<style include="reset">
 			:host {
 				display: block;
 			}


### PR DESCRIPTION
There are a few ways of fixing this issue:

1. Set border-collapse property to !important
2. Set border-collapse property in d2l-table-wrapper
3. Move all styles to d2l-table-wrapper. I was thinking of doing this
already. The reason I didn't was because it would make custom styling of
tables weird

To reproduce:
Add
```html
<link rel="stylesheet" type="text/css" href="https://s.brightspace.com/lib/reset-css/1.1.0/reset.css">
```
to the `<head>` of demo/index.html. Then
```
npm install
polymer serve
open http://localhost:8080/components/d2l-table/demo/
```