### PR TITLE
Fix BSI minification error

### DIFF
--- a/d2l-table-wrapper.html
+++ b/d2l-table-wrapper.html
@@ -22,15 +22,15 @@ Not meant to be used directly. Automatically created when using `<table is="d2l-
 				--d2l-scroll-wrapper-h-scroll: {
 					border-left: var(--d2l-table-border-overflow);
 					border-right: var(--d2l-table-border-overflow);
-				}
+				};
 
 				--d2l-scroll-wrapper-left: {
 					border-left: none;
-				}
+				};
 
 				--d2l-scroll-wrapper-right: {
 					border-right: none;
-				}
+				};
 			}
 		</style>
 		<d2l-scroll-wrapper>


### PR DESCRIPTION
Wierd that polylint didn't catch this...

To Reproduce:

```shell
git clone git@github.com:Brightspace/brightspace-integration.git
cd brightspace-integration
npm install
npm run serve
```

Point an LMS at the local BSI instance. Then open UserProgress (or any page using grid) and change the page size until the horizontal scrollbar appears

To test the fix, run `bower install d2l-table#fix-minification-error` and rerun `npm run serve`