### PR TITLE
US76169 - Hide scroll buttons, and make d2l-scroll-wrapper focusable for keyboard navigation

### DIFF
--- a/d2l-scroll-wrapper.html
+++ b/d2l-scroll-wrapper.html
@@ -199,8 +199,22 @@
 				@apply(--d2l-scroll-wrapper-action-hidden);
 			}
 		</style>
-		<button class="left action" is="d2l-image-action" icon="[[startIcon]]" on-tap="handleTapLeft"></button>
-		<button class="right action" is="d2l-image-action" icon="[[endIcon]]" on-tap="handleTapRight"></button>
+		<button
+			is="d2l-image-action"
+			class="left action"
+			icon="[[startIcon]]"
+			on-tap="handleTapLeft"
+			tabindex="-1"
+			aria-hidden="true"
+		></button>
+		<button
+			is="d2l-image-action"
+			class="right action"
+			icon="[[endIcon]]"
+			on-tap="handleTapRight"
+			tabindex="-1"
+			aria-hidden="true"
+		></button>
 		<content></content>
 	</template>
 	<script>
@@ -396,7 +410,9 @@
 				},
 
 				checkScrollbar: function() {
-					this._setHScrollbar(this.offsetWidth !== this.scrollWidth);
+					var hScrollbar = this.offsetWidth !== this.scrollWidth;
+					this._setHScrollbar(hScrollbar);
+					this.tabIndex = hScrollbar ? 0 : -1;
 					this.checkScrollThresholds();
 				},
 


### PR DESCRIPTION
* Scroll to the d2l-scroll-wrapper, and use the arrow keys

Tested with focus-able elements within the table. The table is still able to scroll with the arrow keys as expected. Tested on Chrome.